### PR TITLE
Add Automated Dataset Download Script for Easy Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This script allows you to **easily download all images** from the National Galle
 chmod +x download_dataset.sh
 ./download_dataset.sh
 ```
+### **Manual Download**
+```sh
+pip install pandas requests tqdm
+python download_dataset.py
+```
+
 ## Additional usage guidelines
 
 ### Images and media files are not included in the dataset.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ The dataset provides data records relating to the 130,000+ artworks in our colle
 
 The dataset is published in CSV format and uses UTF-8 encoding.  A [data dictionary](https://github.com/NationalGalleryOfArt/opendata/blob/master/documentation) fully describes the dataset.
 
+# National Gallery of Art Open Dataset - Image Downloader
+
+This script allows you to **easily download all images** from the National Gallery of Art Open Data dataset.
+
+## 📥 Installation & Usage
+
+### **1️⃣ Prerequisites**
+- Ensure you have **Python 3+** installed.
+- Download the dataset CSV file: [`published_images.csv`](https://github.com/NationalGalleryOfArt/opendata).
+
+### **2️⃣ Automatic Download (Recommended)**
+#### **Windows**
+1. Double-click `download_dataset.bat`
+2. Enter the path to `published_images.csv`
+3. The script will download all images!
+
+#### **Linux/macOS**
+```sh
+chmod +x download_dataset.sh
+./download_dataset.sh
+```
 ## Additional usage guidelines
 
 ### Images and media files are not included in the dataset.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ The dataset is published in CSV format and uses UTF-8 encoding.  A [data diction
 
 This script allows you to **easily download all images** from the National Gallery of Art Open Data dataset.
 
-## 📥 Installation & Usage
+## Installation & Usage
 
-### **1️⃣ Prerequisites**
+### **Prerequisites**
 - Ensure you have **Python 3+** installed.
-- Download the dataset CSV file: [`published_images.csv`](https://github.com/NationalGalleryOfArt/opendata).
+- Download the dataset CSV file: [`published_images.csv`](https://github.com/NationalGalleryOfArt/opendata/blob/main/data/published_images.csv).
 
-### **2️⃣ Automatic Download (Recommended)**
+### **Automatic Download (Recommended)**
 #### **Windows**
 1. Double-click `download_dataset.bat`
 2. Enter the path to `published_images.csv`

--- a/download_data.bat
+++ b/download_data.bat
@@ -1,0 +1,17 @@
+:: Ensure Python is installed
+where python >nul 2>nul
+if %errorlevel% neq 0 (
+    echo Python is not installed! Install Python and try again.
+    exit /b
+)
+
+:: Create virtual environment (optional but recommended)
+python -m venv venv
+call venv\Scripts\activate
+
+:: Install dependencies
+pip install --upgrade pip
+pip install pandas requests tqdm
+
+:: Run Python script
+python download_dataset.py

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Ensure Python is installed
+if ! command -v python3 &> /dev/null; then
+    echo "Python3 not found! Install it and try again."
+    exit 1
+fi
+
+# Create virtual environment (optional but recommended)
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install pandas requests tqdm
+
+# Run Python script
+python3 download_dataset.py

--- a/download_dataset.py
+++ b/download_dataset.py
@@ -1,0 +1,48 @@
+import os
+import pandas as pd
+import requests
+from tqdm import tqdm
+
+# Set default folder
+DEFAULT_SAVE_FOLDER = os.path.join(os.getcwd(), "NGA_Dataset")
+
+def convert_iiif_to_jpg(iiif_url):
+    """Convert IIIF API URL to a direct image download URL."""
+    return iiif_url + "/full/full/0/default.jpg"
+
+def download_image(url, save_folder):
+    """Download an image from a URL and save it to the specified folder."""
+    try:
+        response = requests.get(url, stream=True)
+        if response.status_code == 200:
+            file_name = url.split("/")[-3] + ".jpg"  # Extract unique ID
+            file_path = os.path.join(save_folder, file_name)
+            with open(file_path, 'wb') as file:
+                for chunk in response.iter_content(1024):
+                    file.write(chunk)
+            return True
+    except Exception as e:
+        print(f"Error downloading {url}: {e}")
+    return False
+
+def download_dataset(csv_path, save_folder=DEFAULT_SAVE_FOLDER):
+    """Download all images from the dataset CSV file."""
+    os.makedirs(save_folder, exist_ok=True)
+    df = pd.read_csv(csv_path)
+
+    if 'iiifurl' not in df.columns:
+        print("Error: 'iiifurl' column not found in CSV.")
+        return
+
+    image_urls = df['iiifurl'].dropna().apply(convert_iiif_to_jpg).tolist()
+
+    print(f"Starting download of {len(image_urls)} images...")
+    for url in tqdm(image_urls):
+        download_image(url, save_folder)
+
+    print(f"✅ All images downloaded to: {save_folder}")
+
+if __name__ == "__main__":
+    csv_path = input("Enter the path to published_images.csv: ").strip()
+    save_folder = input(f"Enter save location (default: {DEFAULT_SAVE_FOLDER}): ").strip() or DEFAULT_SAVE_FOLDER
+    download_dataset(csv_path, save_folder)


### PR DESCRIPTION
This PR introduces an automated dataset download script to simplify the process of obtaining the National Gallery of Art Open Dataset. The following additions have been made:

    **download_dataset.py** : A Python script that downloads and stores the dataset efficiently using the IIIF API.

    **download_dataset.sh** : A Bash script for Linux/macOS users to automate the download process.

    **download_dataset.bat** : A Batch script for Windows users to enable easy dataset retrieval.

    Updated **README.md** : Added clear instructions on how to use the scripts to download the dataset.