### PR TITLE
Feature/openaccess and forwarddisplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ TMSPublicExtract (SQL Server)
         |
         v
 extract_opendata.py
-    - Connects via ODBC (Trusted_Connection / Kerberos)
+    - Connects via ODBC
     - Queries 17 x_ tables directly
     - Formats output to match legacy CSV conventions
         |
@@ -42,7 +42,7 @@ TMS → PostgreSQL (vm-webdb-tdp) → psql COPY → CSV → GitHub
 - **Direct SQL Server access**: Removes the PostgreSQL dependency and simplifies the data path.
 - **CSV format compatibility**: Output matches the legacy PostgreSQL `COPY CSV` format exactly — same headers, same quoting rules, same NULL representation — so downstream consumers are unaffected.
 - **Timezone handling**: SQL Server datetimes have no timezone. The script treats them as US Eastern and appends the correct UTC offset (`-04` or `-05`) to match the PostgreSQL `timestamptz` output.
-- **Kerberos authentication**: Uses `Trusted_Connection=yes` with Active Directory service accounts. No passwords are stored in the script or repository.
+- **Authentication**: Uses a service account. No passwords are stored in the script or repository.
 
 ### What the Script Does
 
@@ -75,7 +75,7 @@ extract_opendata.py --server HOST --database DB [--git-push] [--output-dir DIR]
 Tests are in `tests/` and require `pytest` (`pip install pytest`).
 
 - **Unit tests** (`test_csv_formatting.py`): CSV formatting, value conversion, header validation. No database needed.
-- **Integration tests** (`test_database.py`): Runs all 17 queries against the database, validates column counts, row counts, data constraints (e.g., openaccess values are only 0 or 1). Requires database access via service account credentials in `/usr/local/nga/etc/tmspublicextract.conf`. Tests auto-skip gracefully if no database is available.
+- **Integration tests** (`test_database.py`): Runs all 17 queries against the database, validates column counts, row counts, data constraints (e.g., openaccess values are only 0 or 1). Requires database access. Tests auto-skip gracefully if no database is available.
 
 Run all tests:
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,92 @@
+# Architecture
+
+## Overview
+
+The NGA Open Data pipeline extracts collection data from the NGA's TMS (The Museum System) public extract database and publishes it as CSV files to this GitHub repository.
+
+## Data Flow
+
+```
+TMSPublicExtract (SQL Server)
+    x_ tables (permanent, consumer-facing)
+        |
+        v
+extract_opendata.py
+    - Connects via ODBC (Trusted_Connection / Kerberos)
+    - Queries 17 x_ tables directly
+    - Formats output to match legacy CSV conventions
+        |
+        v
+    data/*.csv (17 CSV files)
+        |
+        v (optional --git-push)
+    git add, commit, push → GitHub
+```
+
+## Previous Architecture
+
+The original pipeline used a PostgreSQL intermediary:
+
+```
+TMS → PostgreSQL (vm-webdb-tdp) → psql COPY → CSV → GitHub
+```
+
+`refresh_github_extract.bash` ran `psql` queries defined in `tables.sql`, exported via `COPY ... TO STDOUT WITH CSV HEADER`, then committed and pushed. This required maintaining a separate PostgreSQL database as a staging layer.
+
+## Current Architecture
+
+`extract_opendata.py` queries the TMS public extract SQL Server database directly, eliminating the PostgreSQL intermediary. The x_ tables in TMSPublicExtract are the same tables that fed the PostgreSQL staging database, so the output is equivalent.
+
+### Key Design Decisions
+
+- **Direct SQL Server access**: Removes the PostgreSQL dependency and simplifies the data path.
+- **CSV format compatibility**: Output matches the legacy PostgreSQL `COPY CSV` format exactly — same headers, same quoting rules, same NULL representation — so downstream consumers are unaffected.
+- **Timezone handling**: SQL Server datetimes have no timezone. The script treats them as US Eastern and appends the correct UTC offset (`-04` or `-05`) to match the PostgreSQL `timestamptz` output.
+- **Kerberos authentication**: Uses `Trusted_Connection=yes` with Active Directory service accounts. No passwords are stored in the script or repository.
+
+### What the Script Does
+
+1. Connects to SQL Server via pyodbc (ODBC Driver 18)
+2. Iterates over 17 table definitions (name, headers, SQL query)
+3. For each table: executes the query, formats values, writes CSV
+4. Optionally stages, commits, and pushes to git
+
+```
+extract_opendata.py --server HOST --database DB [--git-push] [--output-dir DIR]
+```
+
+### Formatting Rules
+
+| Type | PostgreSQL COPY | This script |
+|------|----------------|-------------|
+| NULL | empty between commas | empty between commas |
+| Empty string | `""` | `""` |
+| Boolean (bit) | `1`/`0` | `1`/`0` |
+| Timestamp | `2024-01-01 12:00:00-05` | `2024-01-01 12:00:00-05` |
+| Microseconds | `.937000` | `.937` (trailing zeros trimmed) |
+| Comma/quote in string | double-quoted, `""` escaped | double-quoted, `""` escaped |
+
+## Tables Extracted
+
+17 tables covering objects, constituents, locations, images, and relationships. See `documentation/Data Dictionary.txt` for column-level documentation.
+
+## Testing
+
+Tests are in `tests/` and require `pytest` (`pip install pytest`).
+
+- **Unit tests** (`test_csv_formatting.py`): CSV formatting, value conversion, header validation. No database needed.
+- **Integration tests** (`test_database.py`): Runs all 17 queries against the database, validates column counts, row counts, data constraints (e.g., openaccess values are only 0 or 1). Requires database access via service account credentials in `/usr/local/nga/etc/tmspublicextract.conf`. Tests auto-skip gracefully if no database is available.
+
+Run all tests:
+```
+pytest tests/ -v
+```
+
+Run unit tests only (no database):
+```
+pytest tests/test_csv_formatting.py -v
+```
+
+## Deployment
+
+The extraction runs on a scheduled cron job. See the operations team for the current schedule and service account configuration.

--- a/documentation/Data Dictionary.txt
+++ b/documentation/Data Dictionary.txt
@@ -105,6 +105,7 @@ it is possible for some fields, e.g. biography, to have embedded HTML italics ta
 
 (	
     constituentID               integer NOT NULL PRIMARY KEY,	primary key (tms identifier)
+    uuid                        character varying(64) NULL,	universally unique identifier for this constituent
     ULANID                      character varying(32) NULL,	Getty ULAN ID - partially applied to NGA artists - not all artists are in ULAN and not all matches have been curated yet
     preferredDisplayName        character varying(256) NULL,	inverted full name of the constituent - this is the NGA's preferred name for the constituent
     forwardDisplayName          character varying(256) NULL,	forward direction preferred full name of the constituent
@@ -257,6 +258,7 @@ Underscores appearing in nvarchar columns should be treated as an italicizing ma
 
 (	
     objectID                    integer NOT NULL PRIMARY KEY,	the primary identifier for an art object - identifier is created by the NGA's collection management system (tms); primary key for the table
+    uuid                        character varying(64) NULL,	universally unique identifier for this art object
     accessioned                 integer NOT NULL,	0 | 1 flag indicating whether this object is an NGA accessioned work - for the public collection extract, this should always be 1
     accessionNum                character varying(32) NULL,	accession number assigned to an art object - art objects that are not accessioned works do not begin with a year - otherwise, the vast majority of NGA art object accession numbers are formatted with a numbering system starting with the year, then followed by an accession lot, and finally ordering within that lot, e.g. 1942.2.1 - depending on the complexity of an art object these can be more complicated
     locationID                  integer NULL,	location identifier corresponding to the current location of the primary component of the art object

--- a/documentation/Data Dictionary.txt
+++ b/documentation/Data Dictionary.txt
@@ -105,7 +105,6 @@ it is possible for some fields, e.g. biography, to have embedded HTML italics ta
 
 (	
     constituentID               integer NOT NULL PRIMARY KEY,	primary key (tms identifier)
-    uuid			nvarchar(36) NULL,	a persistent unique identifier for this constituent; used as a key into other tables such as alternative numbers and will play a more active role in linking constituents with other data sources moving forward
     ULANID                      character varying(32) NULL,	Getty ULAN ID - partially applied to NGA artists - not all artists are in ULAN and not all matches have been curated yet
     preferredDisplayName        character varying(256) NULL,	inverted full name of the constituent - this is the NGA's preferred name for the constituent
     forwardDisplayName          character varying(256) NULL,	forward direction preferred full name of the constituent
@@ -209,14 +208,6 @@ CREATE TABLE object_associations	relationships between art objects - see accompa
 )	
 	
 	
-CREATE TABLE objects_altnums	relationships between art objects - see accompanying documentation about types of art objects and relationships between them
-
-(	
-  objectid integer NOT NULL,	foreign key to the objects table
-  altnumtype character varying(64) NOT NULL,	type of alternative number, e.g. Stieglitz Estate Number
-  altnum character varying(64) NOT NULL,	the alternative number itself
-)	
-	
 CREATE TABLE objects_constituents	One of the most important elements of the extract, the object / constituent relationships describe the association between a constituent and an object.
 
 (	
@@ -258,11 +249,7 @@ CREATE TABLE objects_historical_data	records a very light audit trail for certai
 	
 CREATE TABLE objects	Art objects are a core entity of the collection extract.  Objects are physical or logical constructs and all but a very small number of them in this extract are NGA objects with accession numbers.
 
-Imagery for an object should not be displayed unless the canShowImagery flag is 1
-
-If an image copyright exists, it must always be displayed with each image of the object
-
-There can be multiple images per object 
+There can be multiple images per object
 
 The begin and end dates are provided to facilitate returning the object via search, but they are no foolproof.  For example, when the displayDate is unset, usually the begin and end dates are the artist’s life dates since that’s the best information available.
 
@@ -270,10 +257,8 @@ Underscores appearing in nvarchar columns should be treated as an italicizing ma
 
 (	
     objectID                    integer NOT NULL PRIMARY KEY,	the primary identifier for an art object - identifier is created by the NGA's collection management system (tms); primary key for the table
-    uuid			nvarchar(36) NULL,	a persistent unique identifier for this art object; used as a key into other tables such as alternative numbers and will play a more active role in linking the art object with other data sources moving forward
     accessioned                 integer NOT NULL,	0 | 1 flag indicating whether this object is an NGA accessioned work - for the public collection extract, this should always be 1
     accessionNum                character varying(32) NULL,	accession number assigned to an art object - art objects that are not accessioned works do not begin with a year - otherwise, the vast majority of NGA art object accession numbers are formatted with a numbering system starting with the year, then followed by an accession lot, and finally ordering within that lot, e.g. 1942.2.1 - depending on the complexity of an art object these can be more complicated
-    objectLeonardoID            character varying(16) NULL,	prior legacy CMS sytem id - might consider moving these to the historical_data table or the object_altnums table
     locationID                  integer NULL,	location identifier corresponding to the current location of the primary component of the art object
     title                       character varying(2048) NULL,	title of the art object
     displayDate                 character varying(256) NULL,	human readable date corresponding to the creation timeframe of the object
@@ -373,8 +358,9 @@ CREATE TABLE published_images Images that have been published to NGA web propert
     viewtype            character varying(32), 		One of “primary” or “alternate” – primary represents a primary view of an art object. Alternate represents an alternate view, typically from another angle, e.g., images from all angles around a sculpture
     sequence            character varying(32),		The order by which to sort images for a given subject, e.g., sequence of images around a sculpture would result in a rotational view around the sculpture.
     width               integer,				The full width of the IIIF source image if it is viewed at the highest zoom level and reassembled into a single image
-    height              integer,				The full width of the IIIF source image if it is viewed at the highest zoom level and reassembled into a single image
+    height              integer,				The full height of the IIIF source image if it is viewed at the highest zoom level and reassembled into a single image
     maxpixels           integer,				A limitation used to enforce fair use doctrine.  When the width and height are larger than the max pixels setting, the image server will only permit sourcing of IIIF services from an image resized to fit within a box of this dimension.  A customer might request a larger image to be produced via IIIF, but the resulting image will blur as the size increases since the source image size is restricted.
+    openaccess          integer NOT NULL,			1 = open access image with no usage restrictions under the NGA’s open access policy. 0 = rights restricted image available only under fair use doctrine.
     created             timestamp with time zone,	Indicates the creation date of the actual source image uploaded to the NGA’s digital asset management system
     modified            timestamp with time zone,	Indicates the modification date of the image metadata record in the digital asset management system – dates tend to be more recent due to automated updates to metadata
     depictstmsobjectid  integer,				Records the Object ID in cases where the image depicts an art object stored in the CMS

--- a/scripts/extract_from_sqlserver.py
+++ b/scripts/extract_from_sqlserver.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Open Data CSV extraction — SQL Server direct.
+Replaces the PostgreSQL-based refresh_github_extract.bash pipeline.
+Queries x_ tables from TMSPublicExtract and outputs CSVs matching
+the exact production headers (lowercase column names, same column order).
+
+Handles formatting differences between SQL Server and PostgreSQL:
+- Booleans (bit): True/False → 1/0
+- Timestamps: adds US Eastern timezone offset (-04/-05)
+- Empty strings: quoted as "" to distinguish from NULL
+- Microseconds: trimmed trailing zeros (.937000 → .937)
+
+Usage:
+  extract_from_sqlserver.py --server HOST --database DB [--git-push] [--output-dir DIR]
+
+Requires --server and --database (or env vars OPENDATA_SERVER, OPENDATA_DATABASE).
+"""
+
+import argparse
+import datetime
+import os
+import subprocess
+import sys
+import pyodbc
+from dateutil import tz
+
+# --- Configuration ---
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_OUTPUT_DIR = os.path.join(SCRIPT_DIR, "..", "data")
+EASTERN = tz.gettz("America/New_York")
+
+# Subquery fragments reused across tables
+ACCESSIONED_OBJECTS = "SELECT DISTINCT objectID FROM x_objects WHERE accessioned = 1"
+ACCESSIONED_CONSTITUENTS = (
+    f"SELECT DISTINCT constituentID FROM x_objects_constituents "
+    f"WHERE objectID IN ({ACCESSIONED_OBJECTS})"
+)
+
+# --- Table definitions ---
+# Each entry: (csv_filename, columns_as_csv_headers, sql_query)
+# Columns listed in exact production CSV header order (lowercase).
+
+TABLES = [
+    (
+        "constituents",
+        ["constituentid", "ulanid", "preferreddisplayname", "forwarddisplayname",
+         "lastname", "displaydate", "artistofngaobject", "beginyear", "endyear",
+         "visualbrowsertimespan", "nationality", "visualbrowsernationality",
+         "constituenttype", "wikidataid"],
+        f"""SELECT constituentID, ULANID, preferredDisplayName, forwardDisplayName,
+                   lastName, displayDate, artistOfNGAObject, beginYear, endYear,
+                   visualBrowserTimeSpan, nationality, visualBrowserNationality,
+                   constituentType, wikidataID
+            FROM x_constituents
+            WHERE constituentID IN ({ACCESSIONED_CONSTITUENTS})
+            ORDER BY constituentID"""
+    ),
+    (
+        "constituents_altnames",
+        ["altnameid", "constituentid", "lastname", "displayname",
+         "forwarddisplayname", "nametype"],
+        # forwardDisplayName: was NULL in the old PostgreSQL pipeline, now populated from source
+        f"""SELECT altNameID, constituentID, lastName, displayName,
+                   forwardDisplayName, nameType
+            FROM x_constituents_altnames
+            WHERE constituentID IN ({ACCESSIONED_CONSTITUENTS})
+            ORDER BY altNameID"""
+    ),
+    (
+        "constituents_text_entries",
+        ["constituentid", "text", "texttype", "year"],
+        "SELECT constituentID, [text], textType, [year] FROM x_constituents_text_entries WHERE textType = 'bibliography' ORDER BY constituentID"
+    ),
+    (
+        "locations",
+        ["locationid", "site", "room", "publicaccess", "description", "unitposition"],
+        "SELECT locationID, site, room, publicAccess, description, unitPosition FROM x_locations ORDER BY locationID"
+    ),
+    (
+        "media_items",
+        ["mediaid", "mediatype", "title", "description", "duration", "language",
+         "thumbnailurl", "playurl", "downloadurl", "keywords", "tags", "imageurl",
+         "presentationdate", "releasedate", "lastmodified"],
+        """SELECT mediaID, mediaType, title, description, duration, language,
+                  thumbnailURL, playURL, downloadURL, keywords, tags, imageURL,
+                  presentationDate, releaseDate, lastModified
+           FROM x_media_items
+           ORDER BY mediaID"""
+    ),
+    (
+        "media_relationships",
+        ["mediaid", "relatedid", "relatedentity"],
+        "SELECT mediaID, relatedID, relatedEntity FROM x_media_relationships ORDER BY mediaID, relatedID"
+    ),
+    (
+        "object_associations",
+        ["parentobjectid", "childobjectid", "relationship"],
+        f"""SELECT DISTINCT a.parentObjectID, a.childObjectID, a.relationship
+            FROM x_object_associations a
+            JOIN x_objects o ON o.objectID IN (a.parentObjectID, a.childObjectID)
+            WHERE o.accessioned = 1
+            ORDER BY a.parentObjectID, a.childObjectID"""
+    ),
+    (
+        "objects",
+        ["objectid", "accessioned", "accessionnum", "locationid", "title",
+         "displaydate", "beginyear", "endyear", "visualbrowsertimespan", "medium",
+         "dimensions", "inscription", "markings", "attributioninverted", "attribution",
+         "provenancetext", "creditline", "classification", "subclassification",
+         "visualbrowserclassification", "parentid", "isvirtual", "departmentabbr",
+         "portfolio", "series", "volume", "watermarks", "lastdetectedmodification",
+         "wikidataid", "customprinturl"],
+        """SELECT o.objectID, o.accessioned, o.accessionNum, o.locationID, o.title,
+                  o.displayDate, o.beginYear, o.endYear, o.visualBrowserTimeSpan,
+                  o.medium, o.dimensions, o.inscription, o.markings,
+                  o.attributionInverted, o.attribution, o.provenanceText, o.creditLine,
+                  o.classification, o.subClassification, o.visualBrowserClassification,
+                  o.parentID, o.isVirtual, o.departmentAbbr, o.portfolio, o.series,
+                  o.volume, o.watermarks, o.lastDetectedModification, o.wikidataID,
+                  p.URL AS customPrintURL
+           FROM x_objects o
+           LEFT JOIN x_objects_customprint_urls p ON p.TMSObjectID = o.objectID
+           WHERE o.accessioned = 1
+           ORDER BY o.objectID"""
+    ),
+    (
+        "alternative_identifiers",
+        ["uuid", "idschemelabel", "identifier"],
+        "SELECT uuid, idSchemeLabel, identifier FROM x_alternative_identifiers WHERE idSchemeLabel <> 'Old CMS Object ID' ORDER BY uuid, idSchemeLabel"
+    ),
+    (
+        "objects_constituents",
+        ["objectid", "constituentid", "displayorder", "roletype", "role", "prefix",
+         "suffix", "displaydate", "beginyear", "endyear", "country", "zipcode"],
+        f"""SELECT objectID, constituentID, displayOrder, roleType, role, prefix,
+                   suffix, displayDate, beginYear, endYear, country, zipCode
+            FROM x_objects_constituents
+            WHERE objectID IN ({ACCESSIONED_OBJECTS})
+            ORDER BY objectID, constituentID"""
+    ),
+    (
+        "objects_dimensions",
+        ["objectid", "element", "dimensiontype", "dimension", "unitname"],
+        f"""SELECT d.objectID, d.element, d.dimensionType, d.dimension, d.unitName
+            FROM x_objects_dimensions d
+            JOIN x_objects o ON o.objectID = d.objectID
+            WHERE o.accessioned = 1
+            ORDER BY d.objectID, d.element, d.dimensionType"""
+    ),
+    (
+        "objects_historical_data",
+        ["datatype", "objectid", "displayorder", "forwardtext", "invertedtext",
+         "remarks", "effectivedate"],
+        f"""SELECT h.dataType, h.objectID, h.displayOrder, h.forwardText,
+                   h.invertedText, h.remarks, h.effectiveDate
+            FROM x_objects_historical_data h
+            JOIN x_objects o ON o.objectID = h.objectID
+            WHERE o.accessioned = 1
+            ORDER BY h.objectID, h.dataType, h.displayOrder"""
+    ),
+    (
+        "objects_terms",
+        ["termid", "objectid", "termtype", "term", "visualbrowsertheme",
+         "visualbrowserstyle"],
+        f"""SELECT t.termID, t.objectID, t.termType, t.term,
+                   t.visualBrowserTheme, t.visualBrowserStyle
+            FROM x_objects_terms t
+            JOIN x_objects o ON o.objectID = t.objectID
+            WHERE o.accessioned = 1
+            ORDER BY t.termID, t.objectID"""
+    ),
+    (
+        "objects_text_entries",
+        ["objectid", "text", "texttype", "year"],
+        f"""SELECT t.objectID, t.[text], t.textType, t.[year]
+            FROM x_objects_text_entries t
+            JOIN x_objects o ON o.objectID = t.objectID
+            WHERE o.accessioned = 1
+              AND t.textType IN ('bibliography','documentary_labels_inscriptions',
+                  'exhibition_history','exhibition_history_footnote',
+                  'inscription_footnote','lifetime_exhibition','other_collections')
+            ORDER BY t.objectID, t.textType"""
+    ),
+    (
+        "preferred_locations",
+        ["locationkey", "locationtype", "description", "ispublicvenue",
+         "mapimageurl", "mapshapetype", "mapshapecoords", "partof"],
+        """SELECT locationKey, locationType, description, isPublicVenue,
+                  mapImageURL, mapShapeType, mapShapeCoords, partOf
+           FROM x_preferred_locations
+           ORDER BY locationKey"""
+    ),
+    (
+        "preferred_locations_tms_locations",
+        ["preferredlocationkey", "tmslocationid"],
+        "SELECT preferredLocationKey, tmsLocationID FROM x_preferred_locations_tms_locations ORDER BY preferredLocationKey, tmsLocationID"
+    ),
+    (
+        "published_images",
+        ["uuid", "iiifurl", "iiifthumburl", "viewtype", "sequence", "width",
+         "height", "maxpixels", "created", "modified", "depictstmsobjectid",
+         "assistivetext"],
+        """SELECT uuid,
+                  CAST('https://api.nga.gov/iiif/' + uuid AS VARCHAR(512)) AS iiifURL,
+                  CAST('https://api.nga.gov/iiif/' + uuid + '/full/!200,200/0/default.jpg' AS VARCHAR(512)) AS iiifThumbURL,
+                  viewType, sequence, width, height, maxPixels, created, modified,
+                  depictsTMSObjectID, assistiveText
+           FROM x_published_images
+           WHERE depictsTMSObjectID IS NOT NULL
+             AND ri_photoCredit IS NULL
+             AND viewType IN ('primary','alternate')
+             AND COALESCE(ri_isDetail,'false') = 'false'
+           ORDER BY uuid"""
+    ),
+]
+
+
+def connect(server, database):
+    connstr = (
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};"
+        f"SERVER={server};DATABASE={database};"
+        f"Trusted_Connection=yes;TrustServerCertificate=yes"
+    )
+    return pyodbc.connect(connstr)
+
+
+def format_datetime(dt):
+    """Format datetime to match PostgreSQL timestamptz output.
+    SQL Server datetime has no timezone — treat as US Eastern and add offset."""
+    aware = dt.replace(tzinfo=EASTERN)
+    offset = aware.strftime("%z")  # e.g. "-0400" or "-0500"
+    offset_short = offset[:3]      # e.g. "-04" or "-05"
+
+    if dt.microsecond:
+        # Trim trailing zeros from fractional seconds: .937000 → .937
+        frac = f"{dt.microsecond:06d}".rstrip("0")
+        ts = dt.strftime("%Y-%m-%d %H:%M:%S") + "." + frac
+    else:
+        ts = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    return ts + offset_short
+
+
+def format_value(v):
+    """Convert a SQL Server value to match PostgreSQL COPY CSV output."""
+    if v is None:
+        return None  # sentinel — will become empty unquoted field
+    if isinstance(v, bool):
+        return str(int(v))
+    if isinstance(v, datetime.datetime):
+        return format_datetime(v)
+    s = str(v)
+    return s
+
+
+# CSV field formatting that matches PostgreSQL COPY behavior:
+# - NULL → empty between commas (no quotes)
+# - empty string → "" (quoted)
+# - strings with comma/quote/newline → quoted
+# - everything else → unquoted
+
+def needs_quoting(s):
+    return '"' in s or ',' in s or '\n' in s or '\r' in s
+
+
+def write_csv_row(f, values):
+    """Write one CSV row matching PostgreSQL COPY CSV format."""
+    parts = []
+    for v in values:
+        if v is None:
+            parts.append("")
+        elif v == "":
+            parts.append('""')
+        elif needs_quoting(v):
+            parts.append('"' + v.replace('"', '""') + '"')
+        else:
+            parts.append(v)
+    f.write(",".join(parts) + "\n")
+
+
+def extract_table(conn, name, headers, query, output_dir):
+    """Run query and write CSV. Returns row count."""
+    path = os.path.join(output_dir, f"{name}.csv")
+    cur = conn.cursor()
+    cur.execute(query)
+
+    count = 0
+    with open(path, "w", encoding="utf-8") as f:
+        # Header row — plain comma-separated, no quoting needed
+        f.write(",".join(headers) + "\n")
+        for row in cur:
+            formatted = [format_value(v) for v in row]
+            write_csv_row(f, formatted)
+            count += 1
+    cur.close()
+    return count
+
+
+def git_push(output_dir):
+    """Stage CSVs, commit with date, and push."""
+    repo_dir = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"], cwd=output_dir
+    ).decode().strip()
+    def run(cmd):
+        subprocess.check_call(cmd, cwd=repo_dir)
+    run(["git", "pull"])
+    run(["git", "add", output_dir])
+    # Skip commit+push if nothing changed
+    if subprocess.call(["git", "diff", "--cached", "--quiet"], cwd=repo_dir) == 0:
+        print("Git: no changes to commit")
+        return
+    msg = datetime.datetime.now().strftime("%Y-%m-%d") + " data export"
+    run(["git", "commit", "-m", msg])
+    run(["git", "push"])
+    print(f"Git: committed and pushed ({msg})")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Open Data CSV extraction from SQL Server")
+    p.add_argument("--server", default=os.environ.get("OPENDATA_SERVER"),
+                   help="SQL Server hostname (or set OPENDATA_SERVER)")
+    p.add_argument("--database", default=os.environ.get("OPENDATA_DATABASE"),
+                   help="Database name (or set OPENDATA_DATABASE)")
+    p.add_argument("--output-dir", help="Output directory (default: ../data)")
+    p.add_argument("--git-push", action="store_true",
+                   help="Git add, commit, and push after extraction")
+    args = p.parse_args()
+    if not args.server or not args.database:
+        p.error("--server and --database are required (or set OPENDATA_SERVER / OPENDATA_DATABASE)")
+    return args
+
+
+def main():
+    args = parse_args()
+
+    server = args.server
+    database = args.database
+    output_dir = args.output_dir or DEFAULT_OUTPUT_DIR
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"Connecting to {server}/{database} ...")
+    conn = connect(server, database)
+    print("Connected.\n")
+
+    try:
+        total = 0
+        for name, headers, query in TABLES:
+            count = extract_table(conn, name, headers, query, output_dir)
+            total += count
+            print(f"  {name}: {count:,} rows")
+    finally:
+        conn.close()
+
+    print(f"\nDone. {len(TABLES)} tables, {total:,} total rows.")
+    print(f"Output: {output_dir}")
+
+    if args.git_push:
+        git_push(output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_opendata.py
+++ b/scripts/extract_opendata.py
@@ -44,11 +44,11 @@ ACCESSIONED_CONSTITUENTS = (
 TABLES = [
     (
         "constituents",
-        ["constituentid", "ulanid", "preferreddisplayname", "forwarddisplayname",
+        ["constituentid", "uuid", "ulanid", "preferreddisplayname", "forwarddisplayname",
          "lastname", "displaydate", "artistofngaobject", "beginyear", "endyear",
          "visualbrowsertimespan", "nationality", "visualbrowsernationality",
          "constituenttype", "wikidataid"],
-        f"""SELECT constituentID, ULANID, preferredDisplayName, forwardDisplayName,
+        f"""SELECT constituentID, uuid, ULANID, preferredDisplayName, forwardDisplayName,
                    lastName, displayDate, artistOfNGAObject, beginYear, endYear,
                    visualBrowserTimeSpan, nationality, visualBrowserNationality,
                    constituentType, wikidataID
@@ -104,14 +104,14 @@ TABLES = [
     ),
     (
         "objects",
-        ["objectid", "accessioned", "accessionnum", "locationid", "title",
+        ["objectid", "uuid", "accessioned", "accessionnum", "locationid", "title",
          "displaydate", "beginyear", "endyear", "visualbrowsertimespan", "medium",
          "dimensions", "inscription", "markings", "attributioninverted", "attribution",
          "provenancetext", "creditline", "classification", "subclassification",
          "visualbrowserclassification", "parentid", "isvirtual", "departmentabbr",
          "portfolio", "series", "volume", "watermarks", "lastdetectedmodification",
          "wikidataid", "customprinturl"],
-        """SELECT o.objectID, o.accessioned, o.accessionNum, o.locationID, o.title,
+        """SELECT o.objectID, o.uuid, o.accessioned, o.accessionNum, o.locationID, o.title,
                   o.displayDate, o.beginYear, o.endYear, o.visualBrowserTimeSpan,
                   o.medium, o.dimensions, o.inscription, o.markings,
                   o.attributionInverted, o.attribution, o.provenanceText, o.creditLine,

--- a/scripts/extract_opendata.py
+++ b/scripts/extract_opendata.py
@@ -12,7 +12,7 @@ Handles formatting differences between SQL Server and PostgreSQL:
 - Microseconds: trimmed trailing zeros (.937000 → .937)
 
 Usage:
-  extract_from_sqlserver.py --server HOST --database DB [--git-push] [--output-dir DIR]
+  extract_opendata.py --server HOST --database DB [--git-push] [--output-dir DIR]
 
 Requires --server and --database (or env vars OPENDATA_SERVER, OPENDATA_DATABASE).
 """
@@ -199,13 +199,14 @@ TABLES = [
     (
         "published_images",
         ["uuid", "iiifurl", "iiifthumburl", "viewtype", "sequence", "width",
-         "height", "maxpixels", "created", "modified", "depictstmsobjectid",
-         "assistivetext"],
+         "height", "maxpixels", "openaccess", "created", "modified",
+         "depictstmsobjectid", "assistivetext"],
         """SELECT uuid,
                   CAST('https://api.nga.gov/iiif/' + uuid AS VARCHAR(512)) AS iiifURL,
                   CAST('https://api.nga.gov/iiif/' + uuid + '/full/!200,200/0/default.jpg' AS VARCHAR(512)) AS iiifThumbURL,
-                  viewType, sequence, width, height, maxPixels, created, modified,
-                  depictsTMSObjectID, assistiveText
+                  viewType, sequence, width, height, maxPixels,
+                  CASE WHEN obj_rightsType = 'Open Access' THEN 1 ELSE 0 END AS openAccess,
+                  created, modified, depictsTMSObjectID, assistiveText
            FROM x_published_images
            WHERE depictsTMSObjectID IS NOT NULL
              AND ri_photoCredit IS NULL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for the test suite."""
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+CONF_FILE = "/usr/local/nga/etc/tmspublicextract.conf"
+
+
+def _read_conf():
+    """Read connection settings from the public extract conf file."""
+    conf = {}
+    try:
+        with open(CONF_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if "=" in line and not line.startswith("#"):
+                    key, val = line.split("=", 1)
+                    conf[key.strip()] = val.strip().strip('"')
+    except (IOError, PermissionError):
+        return conf
+    return conf
+
+
+def _kinit_service_account():
+    """Get a Kerberos ticket for the service account using a private ccache."""
+    conf = _read_conf()
+    user = conf.get("tmspublicextract_username")
+    password = conf.get("tmspublicextract_password")
+    if not user or not password:
+        return None
+    ccache = os.path.join(tempfile.gettempdir(), "krb5cc_opendata_test")
+    principal = "{}@NGA.GOV".format(user)
+    proc = subprocess.run(
+        ["kinit", principal],
+        input=password + "\n",
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env=dict(os.environ, KRB5CCNAME="FILE:" + ccache),
+    )
+    if proc.returncode != 0:
+        return None
+    return ccache
+
+
+def pytest_addoption(parser):
+    conf = _read_conf()
+    parser.addoption("--server", default=os.environ.get(
+        "OPENDATA_SERVER", conf.get("tmspublicextract_server", "ap-tmstst-db")))
+    parser.addoption("--database", default=os.environ.get(
+        "OPENDATA_DATABASE", conf.get("tmspublicextract_database", "TMSPublicExtract")))
+
+
+@pytest.fixture(scope="session")
+def db(request):
+    """Connect via Kerberos using service account credentials from conf file."""
+    try:
+        import extract_opendata as ext
+    except ImportError:
+        pytest.skip("extract_opendata not importable")
+
+    # Get a service account Kerberos ticket (separate ccache, won't touch user's ticket)
+    ccache = _kinit_service_account()
+    if ccache:
+        os.environ["KRB5CCNAME"] = "FILE:" + ccache
+    # else: fall back to whatever ticket is already available
+
+    server = request.config.getoption("--server")
+    database = request.config.getoption("--database")
+    try:
+        conn = ext.connect(server, database)
+    except Exception as e:
+        pytest.skip("Cannot connect to {}/{}: {}".format(server, database, e))
+    yield conn
+    conn.close()

--- a/tests/test_csv_formatting.py
+++ b/tests/test_csv_formatting.py
@@ -1,0 +1,164 @@
+"""Unit tests for CSV formatting functions in extract_opendata.py."""
+import datetime
+import io
+import os
+import sys
+
+import pytest
+
+# Add scripts/ to path so we can import the extraction module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import extract_opendata as ext
+
+
+# --- format_datetime ---
+
+class TestFormatDatetime:
+    def test_winter_offset(self):
+        """January datetime should get -05 (EST)."""
+        dt = datetime.datetime(2024, 1, 15, 10, 30, 0)
+        assert ext.format_datetime(dt).endswith("-05")
+
+    def test_summer_offset(self):
+        """July datetime should get -04 (EDT)."""
+        dt = datetime.datetime(2024, 7, 15, 10, 30, 0)
+        assert ext.format_datetime(dt).endswith("-04")
+
+    def test_microseconds_trimmed(self):
+        """.937000 should become .937"""
+        dt = datetime.datetime(2024, 1, 1, 0, 0, 0, 937000)
+        result = ext.format_datetime(dt)
+        assert ".937-" in result
+        assert ".937000" not in result
+
+    def test_microseconds_single_trailing(self):
+        """.100000 should become .1"""
+        dt = datetime.datetime(2024, 1, 1, 0, 0, 0, 100000)
+        result = ext.format_datetime(dt)
+        assert ".1-" in result
+
+    def test_no_microseconds(self):
+        """No fractional part when microseconds=0."""
+        dt = datetime.datetime(2024, 1, 1, 12, 0, 0, 0)
+        result = ext.format_datetime(dt)
+        # Extract seconds portion (after last ":" up to offset)
+        assert result == "2024-01-01 12:00:00-05"
+
+    def test_full_format(self):
+        dt = datetime.datetime(2024, 6, 15, 14, 30, 45, 123000)
+        result = ext.format_datetime(dt)
+        assert result == "2024-06-15 14:30:45.123-04"
+
+
+# --- format_value ---
+
+class TestFormatValue:
+    def test_none(self):
+        assert ext.format_value(None) is None
+
+    def test_true(self):
+        assert ext.format_value(True) == "1"
+
+    def test_false(self):
+        assert ext.format_value(False) == "0"
+
+    def test_integer(self):
+        assert ext.format_value(42) == "42"
+
+    def test_float(self):
+        assert ext.format_value(3.14) == "3.14"
+
+    def test_string(self):
+        assert ext.format_value("hello") == "hello"
+
+    def test_empty_string(self):
+        assert ext.format_value("") == ""
+
+    def test_datetime(self):
+        dt = datetime.datetime(2024, 1, 1, 0, 0, 0)
+        result = ext.format_value(dt)
+        assert "2024-01-01" in result
+        assert "-05" in result
+
+
+# --- needs_quoting ---
+
+class TestNeedsQuoting:
+    def test_comma(self):
+        assert ext.needs_quoting("a,b") is True
+
+    def test_double_quote(self):
+        assert ext.needs_quoting('say "hi"') is True
+
+    def test_newline(self):
+        assert ext.needs_quoting("line1\nline2") is True
+
+    def test_carriage_return(self):
+        assert ext.needs_quoting("line1\rline2") is True
+
+    def test_plain_text(self):
+        assert ext.needs_quoting("plain text") is False
+
+    def test_empty(self):
+        assert ext.needs_quoting("") is False
+
+
+# --- write_csv_row ---
+
+class TestWriteCsvRow:
+    def _write(self, values):
+        buf = io.StringIO()
+        ext.write_csv_row(buf, values)
+        return buf.getvalue()
+
+    def test_none_becomes_empty(self):
+        assert self._write([None]) == "\n"
+
+    def test_empty_string_quoted(self):
+        assert self._write([""]) == '""\n'
+
+    def test_string_with_comma(self):
+        assert self._write(["a,b"]) == '"a,b"\n'
+
+    def test_embedded_quotes(self):
+        assert self._write(['say "hi"']) == '"say ""hi"""\n'
+
+    def test_mixed_row(self):
+        result = self._write([None, "", "plain", "a,b"])
+        assert result == ',"",' + 'plain,"a,b"\n'
+
+    def test_all_none(self):
+        result = self._write([None, None, None])
+        assert result == ",,\n"
+
+    def test_plain_unquoted(self):
+        result = self._write(["hello", "world"])
+        assert result == "hello,world\n"
+
+
+# --- TABLES list structure ---
+
+class TestTablesDefinition:
+    def test_table_count(self):
+        assert len(ext.TABLES) > 0
+
+    def test_each_entry_is_triple(self):
+        for entry in ext.TABLES:
+            assert len(entry) == 3, f"Entry {entry[0]} should be (name, headers, query)"
+
+    def test_no_duplicate_names(self):
+        names = [t[0] for t in ext.TABLES]
+        assert len(names) == len(set(names))
+
+    def test_headers_are_lowercase(self):
+        for name, headers, _ in ext.TABLES:
+            for h in headers:
+                assert h == h.lower(), f"{name}: header '{h}' not lowercase"
+
+    def test_published_images_has_openaccess(self):
+        for name, headers, _ in ext.TABLES:
+            if name == "published_images":
+                assert "openaccess" in headers
+                break
+        else:
+            pytest.fail("published_images not found in TABLES")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,163 @@
+"""Integration tests requiring a SQL Server connection.
+
+Runs read-only queries against TMSPublicExtract to verify extraction
+queries execute correctly. Skips automatically if DB is unreachable.
+
+Connection uses Kerberos via service account credentials from
+/usr/local/nga/etc/tmspublicextract.conf (see conftest.py).
+
+Usage:
+  pytest tests/test_database.py -v
+  pytest tests/test_database.py -v --server ap-tmstst-db --database TMSPublicExtract
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import extract_opendata as ext
+
+# db fixture is provided by conftest.py
+
+
+# --- Connection ---
+
+class TestConnection:
+    def test_connects(self, db):
+        cur = db.cursor()
+        cur.execute("SELECT 1")
+        assert cur.fetchone()[0] == 1
+        cur.close()
+
+
+# --- All 17 queries execute without error ---
+
+@pytest.mark.parametrize("name,headers,query", ext.TABLES, ids=[t[0] for t in ext.TABLES])
+class TestQueryExecution:
+    def test_query_runs(self, db, name, headers, query):
+        """Query executes without SQL error."""
+        cur = db.cursor()
+        cur.execute(query)
+        cur.fetchone()
+        cur.close()
+
+    def test_column_count_matches_headers(self, db, name, headers, query):
+        """Result set column count matches headers list."""
+        cur = db.cursor()
+        cur.execute(query)
+        row = cur.fetchone()
+        if row is not None:
+            assert len(row) == len(headers), (
+                "{}: query returns {} cols but headers has {}".format(name, len(row), len(headers))
+            )
+        cur.close()
+
+    def test_returns_rows(self, db, name, headers, query):
+        """Query returns at least one row."""
+        cur = db.cursor()
+        cur.execute(query)
+        row = cur.fetchone()
+        assert row is not None, "{}: query returned 0 rows".format(name)
+        cur.close()
+
+
+# --- Published images openaccess column ---
+
+class TestOpenAccess:
+    def test_only_zero_or_one(self, db):
+        """openaccess column produces only 0 or 1."""
+        cur = db.cursor()
+        cur.execute("""
+            SELECT DISTINCT CASE WHEN obj_rightsType = 'Open Access' THEN 1 ELSE 0 END
+            FROM x_published_images
+            WHERE depictsTMSObjectID IS NOT NULL
+              AND ri_photoCredit IS NULL
+              AND viewType IN ('primary','alternate')
+              AND COALESCE(ri_isDetail,'false') = 'false'
+        """)
+        values = {row[0] for row in cur.fetchall()}
+        cur.close()
+        assert values <= {0, 1}
+
+    def test_has_open_access_rows(self, db):
+        """At least some images are open access."""
+        cur = db.cursor()
+        cur.execute("""
+            SELECT COUNT(*) FROM x_published_images
+            WHERE obj_rightsType = 'Open Access'
+              AND depictsTMSObjectID IS NOT NULL
+              AND ri_photoCredit IS NULL
+              AND viewType IN ('primary','alternate')
+              AND COALESCE(ri_isDetail,'false') = 'false'
+        """)
+        count = cur.fetchone()[0]
+        cur.close()
+        assert count > 0, "No open access images found"
+
+    def test_has_restricted_rows(self, db):
+        """At least some images are rights restricted."""
+        cur = db.cursor()
+        cur.execute("""
+            SELECT COUNT(*) FROM x_published_images
+            WHERE (obj_rightsType IS NULL OR obj_rightsType <> 'Open Access')
+              AND depictsTMSObjectID IS NOT NULL
+              AND ri_photoCredit IS NULL
+              AND viewType IN ('primary','alternate')
+              AND COALESCE(ri_isDetail,'false') = 'false'
+        """)
+        count = cur.fetchone()[0]
+        cur.close()
+        assert count > 0, "No rights-restricted images found"
+
+
+# --- Row count sanity (order-of-magnitude checks) ---
+
+class TestRowCounts:
+    """Verify row counts are in expected ranges for a populated database."""
+
+    EXPECTED_MINIMUMS = {
+        "objects": 100000,
+        "constituents": 10000,
+        "published_images": 50000,
+        "objects_constituents": 100000,
+        "objects_terms": 100000,
+        "locations": 1000,
+    }
+
+    @pytest.mark.parametrize("name,headers,query", ext.TABLES, ids=[t[0] for t in ext.TABLES])
+    def test_minimum_rows(self, db, name, headers, query):
+        if name not in self.EXPECTED_MINIMUMS:
+            pytest.skip("No minimum defined for {}".format(name))
+        # Strip ORDER BY — SQL Server disallows it in derived tables
+        import re
+        q = re.sub(r'\s+ORDER BY\s+[^)]+$', '', query, flags=re.IGNORECASE)
+        cur = db.cursor()
+        cur.execute("SELECT COUNT(*) FROM ({}) AS q".format(q))
+        count = cur.fetchone()[0]
+        cur.close()
+        minimum = self.EXPECTED_MINIMUMS[name]
+        assert count >= minimum, "{}: {} rows < expected minimum {}".format(name, count, minimum)
+
+
+# --- No internal columns leak ---
+
+class TestNoInternalColumns:
+    """Verify internal columns don't appear in query results."""
+
+    INTERNAL_COLS = {"_row_updated_at", "_row_hash", "fingerprint", "ri_photocredit", "ri_isdetail"}
+
+    @pytest.mark.parametrize("name,headers,query", ext.TABLES, ids=[t[0] for t in ext.TABLES])
+    def test_no_internal_columns_in_headers(self, name, headers, query):
+        leaked = self.INTERNAL_COLS & set(headers)
+        assert not leaked, "{}: internal columns in headers: {}".format(name, leaked)
+
+    @pytest.mark.parametrize("name,headers,query", ext.TABLES, ids=[t[0] for t in ext.TABLES])
+    def test_no_internal_columns_in_results(self, db, name, headers, query):
+        """Check result set column names don't include internal fields."""
+        cur = db.cursor()
+        cur.execute(query)
+        col_names = {col[0].lower() for col in cur.description}
+        cur.close()
+        leaked = self.INTERNAL_COLS & col_names
+        assert not leaked, "{}: internal columns in result set: {}".format(name, leaked)


### PR DESCRIPTION
Updated the open data extract to:
* converted from shell script + legacy postgres db to python with TMS public extract
* added uuids for objects and constituents that were in the data dictionary but missing from objects and constituents columns
* added an openaccess column for published images which had been previously requested in a public submitted github issue - not all copyright statuses are listed here - just a yes/no for open access status.
* added tests and an ARCH document